### PR TITLE
S-shape layout available

### DIFF
--- a/VR Contrast Project/Assets/Scenes/TutorialScene.unity
+++ b/VR Contrast Project/Assets/Scenes/TutorialScene.unity
@@ -2360,7 +2360,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   currentTime: 0
-  maxTime: 1000
+  maxTime: 300
   timerUI: {fileID: 1563147757}
   isCounting: 0
   levelController: {fileID: 1130989966}
@@ -9417,6 +9417,7 @@ MonoBehaviour:
   - {x: -3.041457, y: 0, z: -2.8151855}
   - {x: -3.039848, y: 0, z: -2.811016}
   - {x: -3.004004, y: 0, z: -2.8333995}
+  isResearch: 1
   levelOneHandUI: {fileID: 1696415711}
   wristTimer: {fileID: 368718712}
   xIndex: 0
@@ -9486,6 +9487,78 @@ MonoBehaviour:
   - {fileID: 2100000, guid: a3fda9307ae8f6e48ac4018ad94dca94, type: 2}
   - {fileID: 2100000, guid: fa6394c83f3939940ac347723c2da4bc, type: 2}
   - {fileID: 2100000, guid: dc60edc8e68f4e04193add786e13d778, type: 2}
+  - {fileID: 2100000, guid: f1e1b523b9c698a46bfc8fc38cc5ec19, type: 2}
+  - {fileID: 2100000, guid: ba8115094a282f14380d0b7266c2f039, type: 2}
+  - {fileID: 2100000, guid: 3a3fbba70a53e0243b0c21a7f01a6165, type: 2}
+  - {fileID: 2100000, guid: f96ef3d4d6190da4f9dcc7c4f52af951, type: 2}
+  - {fileID: 2100000, guid: 5859d2ff09264f44ab87ec07fc3aef3c, type: 2}
+  - {fileID: 2100000, guid: 1476db012d43330458e0abb73c636f14, type: 2}
+  - {fileID: 2100000, guid: 2f59facb378042046bc6ca00e15c16a0, type: 2}
+  levelResearchXZeroImages:
+  - {fileID: 2100000, guid: 389977410f94364459da5c55bbe217db, type: 2}
+  - {fileID: 2100000, guid: b71ea0e10a834bb4496df5e977e24410, type: 2}
+  - {fileID: 2100000, guid: 99f111545006d924aad1cc56dc2f1634, type: 2}
+  - {fileID: 2100000, guid: c1990d8f862d1724aa38935f37d30411, type: 2}
+  - {fileID: 2100000, guid: 1568c4103657f834fa540f867a5861a9, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: 51d98ca0a73153b4aa1cb7911aeb5cd7, type: 2}
+  levelResearchXOneImages:
+  - {fileID: 2100000, guid: 39ecb050ff0596f4f90a571869e4bad1, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: 52d7349f3155fc240be54fe46c0ca807, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: 0b1f65a4ae4bfd94c874bd6a27aecfab, type: 2}
+  levelResearchXTwoImages:
+  - {fileID: 2100000, guid: 6c8a0539dd07cbc478c54df462837cd2, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: 484b4008bdf5465449a3dc466399aab3, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: 9d4bccc2cff81f447bdf62fcae0c5a23, type: 2}
+  levelResearchXThreeImages:
+  - {fileID: 2100000, guid: 8db1b59ed4a21484e939c1dccbc11f56, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: 26c9f69dbc4035249afeae54b4f500b8, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: c2b7c2e8f46471644aa479e173063e57, type: 2}
+  levelResearchXFourImages:
+  - {fileID: 2100000, guid: 569a9aef79d3723488110d959ad0f83b, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: 589d9c7bc4bc1d2478db008f68d2ed68, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 2100000, guid: e403110279b52a74ea62cbddfef59e73, type: 2}
+  levelResearchXFiveImages:
+  - {fileID: 2100000, guid: 369ed581eb572c247ac045d42fc0fa3a, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 2100000, guid: f1e1b523b9c698a46bfc8fc38cc5ec19, type: 2}
   - {fileID: 2100000, guid: ba8115094a282f14380d0b7266c2f039, type: 2}
   - {fileID: 2100000, guid: 3a3fbba70a53e0243b0c21a7f01a6165, type: 2}

--- a/VR Contrast Project/Assets/Scripts/ChangeSkybox.cs
+++ b/VR Contrast Project/Assets/Scripts/ChangeSkybox.cs
@@ -36,6 +36,8 @@ public class ChangeSkybox : MonoBehaviour
 
     // level one info
     [Header("Level One --------")]
+    [Header("Research Status")]
+    public bool isResearch = true;
     [Header("UI")]
     public GameObject levelOneHandUI;
     public TimerCountdown wristTimer;
@@ -50,13 +52,22 @@ public class ChangeSkybox : MonoBehaviour
     
     [Header("Top-Down Map")] // 2D array acts as top down grid of map
     public Material[,] levelOneImages = new Material[levelOneX, levelOneY];
-    [Header("Map columns")] // each one-dimensional array holds data for each column in 2D array
+    public Material[,] levelResearchImages = new Material[levelOneX, levelOneY];
+    [Header("Map columns (Grid)")] // each one-dimensional array holds data for each column in 2D array
     public Material[] levelOneXZeroImages = new Material[levelOneY];
     public Material[] levelOneXOneImages = new Material[levelOneY];
     public Material[] levelOneXTwoImages = new Material[levelOneY];
     public Material[] levelOneXThreeImages = new Material[levelOneY];
     public Material[] levelOneXFourImages = new Material[levelOneY];
     public Material[] levelOneXFiveImages = new Material[levelOneY];
+    [Header("Map columns (S-shape)")]
+    // setup for research with limited movement (S-shape)
+    public Material[] levelResearchXZeroImages = new Material[levelOneY];
+    public Material[] levelResearchXOneImages = new Material[levelOneY];
+    public Material[] levelResearchXTwoImages = new Material[levelOneY];
+    public Material[] levelResearchXThreeImages = new Material[levelOneY];
+    public Material[] levelResearchXFourImages = new Material[levelOneY];
+    public Material[] levelResearchXFiveImages = new Material[levelOneY];
     [Header("Path indicators")]
     public GameObject pathNorth;
     public GameObject buttonNorth;
@@ -229,13 +240,26 @@ public class ChangeSkybox : MonoBehaviour
         Material[] currentArray;
         // hold a reference to all arrays for use within nested loop below
         List<Material[]> arrays = new List<Material[]>();
-        // assigning values at initialisation did not work, therefore this is used
-        arrays.Add(levelOneXZeroImages);
-        arrays.Add(levelOneXOneImages);
-        arrays.Add(levelOneXTwoImages);
-        arrays.Add(levelOneXThreeImages);
-        arrays.Add(levelOneXFourImages);
-        arrays.Add(levelOneXFiveImages);
+        if (isResearch)
+        {
+            // assigning values at initialisation did not work, therefore this is used
+            arrays.Add(levelResearchXZeroImages);
+            arrays.Add(levelResearchXOneImages);
+            arrays.Add(levelResearchXTwoImages);
+            arrays.Add(levelResearchXThreeImages);
+            arrays.Add(levelResearchXFourImages);
+            arrays.Add(levelResearchXFiveImages);
+        }
+        else
+        {
+            // assigning values at initialisation did not work, therefore this is used
+            arrays.Add(levelOneXZeroImages);
+            arrays.Add(levelOneXOneImages);
+            arrays.Add(levelOneXTwoImages);
+            arrays.Add(levelOneXThreeImages);
+            arrays.Add(levelOneXFourImages);
+            arrays.Add(levelOneXFiveImages);
+        }
 
         for (int i = 0; i < levelOneX; i++)
         {

--- a/VR Contrast Project/Assets/Scripts/TimerCountdown.cs
+++ b/VR Contrast Project/Assets/Scripts/TimerCountdown.cs
@@ -48,7 +48,8 @@ public class TimerCountdown : MonoBehaviour
         // only used when timer is not needed in a level
         if (timeInSeconds == Mathf.Infinity)
         {
-            timerUI.text = "infi\nnity";
+            // display 5 minutes 0 seconds while not counting down
+            timerUI.text = string.Format("{0:00}\n{1:00}", 5f, 0f); ;
         }
         else
         {


### PR DESCRIPTION
Added an "isResearch" bool which, when true, loads the grid with skyboxes only within the S-shape for research. This can be improved upon massively in future by removing the need for separate Material arrays for research and not for research, and simply eliminating specific skyboxes, but this is a very quick fix for now.